### PR TITLE
DeArrow alternative domain

### DIFF
--- a/app/src/main/java/app/revanced/integrations/youtube/patches/alternativethumbnails/AlternativeThumbnailsPatch.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/patches/alternativethumbnails/AlternativeThumbnailsPatch.java
@@ -1,6 +1,7 @@
 package app.revanced.integrations.youtube.patches.alternativethumbnails;
 
 import static app.revanced.integrations.shared.utils.StringRef.str;
+import static app.revanced.integrations.youtube.settings.Settings.ALT_THUMBNAIL_ALTERNATIVE_DOMAIN;
 import static app.revanced.integrations.youtube.settings.Settings.ALT_THUMBNAIL_HOME;
 import static app.revanced.integrations.youtube.settings.Settings.ALT_THUMBNAIL_LIBRARY;
 import static app.revanced.integrations.youtube.settings.Settings.ALT_THUMBNAIL_PLAYER;
@@ -264,6 +265,9 @@ public final class AlternativeThumbnailsPatch {
      */
     public static String overrideImageURL(String originalUrl) {
         try {
+            if (ALT_THUMBNAIL_ALTERNATIVE_DOMAIN.get())
+                originalUrl = originalUrl.replaceAll("yt3.ggpht.com", "yt4.ggpht.com");
+
             ThumbnailOption option = optionSettingForCurrentNavigation();
 
             if (option == ThumbnailOption.ORIGINAL) {

--- a/app/src/main/java/app/revanced/integrations/youtube/patches/alternativethumbnails/AlternativeThumbnailsPatch.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/patches/alternativethumbnails/AlternativeThumbnailsPatch.java
@@ -1,7 +1,10 @@
 package app.revanced.integrations.youtube.patches.alternativethumbnails;
 
 import static app.revanced.integrations.shared.utils.StringRef.str;
-import static app.revanced.integrations.youtube.settings.Settings.ALT_THUMBNAIL_ALTERNATIVE_DOMAIN;
+
+
+import static app.revanced.integrations.youtube.settings.Settings.ALT_THUMBNAIL_ALTERNATIVE_DOMAIN_NAME;
+import static app.revanced.integrations.youtube.settings.Settings.ALT_THUMBNAIL_ALTERNATIVE_DOMAIN_ENABLE;
 import static app.revanced.integrations.youtube.settings.Settings.ALT_THUMBNAIL_HOME;
 import static app.revanced.integrations.youtube.settings.Settings.ALT_THUMBNAIL_LIBRARY;
 import static app.revanced.integrations.youtube.settings.Settings.ALT_THUMBNAIL_PLAYER;
@@ -68,6 +71,13 @@ public final class AlternativeThumbnailsPatch {
         @Override
         public boolean isAvailable() {
             return usingDeArrowAnywhere();
+        }
+    }
+
+    public static final class DeArrowAlternativeDomainAvailability implements Setting.Availability {
+        @Override
+        public boolean isAvailable() {
+            return ALT_THUMBNAIL_ALTERNATIVE_DOMAIN_ENABLE.get();
         }
     }
 
@@ -265,8 +275,8 @@ public final class AlternativeThumbnailsPatch {
      */
     public static String overrideImageURL(String originalUrl) {
         try {
-            if (ALT_THUMBNAIL_ALTERNATIVE_DOMAIN.get())
-                originalUrl = originalUrl.replaceAll("yt3.ggpht.com", "yt4.ggpht.com");
+            if (ALT_THUMBNAIL_ALTERNATIVE_DOMAIN_ENABLE.get() && originalUrl.contains("yt3.ggpht.com"))
+                originalUrl = originalUrl.replaceAll("yt3.ggpht.com", ALT_THUMBNAIL_ALTERNATIVE_DOMAIN_NAME.get());
 
             ThumbnailOption option = optionSettingForCurrentNavigation();
 

--- a/app/src/main/java/app/revanced/integrations/youtube/settings/Settings.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/settings/Settings.java
@@ -58,6 +58,7 @@ public class Settings extends BaseSettings {
     public static final BooleanSetting ALT_THUMBNAIL_DEARROW_CONNECTION_TOAST = new BooleanSetting("revanced_alt_thumbnail_dearrow_connection_toast", FALSE, new DeArrowAvailability());
     public static final EnumSetting<ThumbnailStillTime> ALT_THUMBNAIL_STILLS_TIME = new EnumSetting<>("revanced_alt_thumbnail_stills_time", ThumbnailStillTime.MIDDLE, new StillImagesAvailability());
     public static final BooleanSetting ALT_THUMBNAIL_STILLS_FAST = new BooleanSetting("revanced_alt_thumbnail_stills_fast", FALSE, new StillImagesAvailability());
+    public static final BooleanSetting ALT_THUMBNAIL_ALTERNATIVE_DOMAIN = new BooleanSetting("revanced_alt_thumbnail_alternative_domain", FALSE);
 
 
     // PreferenceScreen: Feed

--- a/app/src/main/java/app/revanced/integrations/youtube/settings/Settings.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/settings/Settings.java
@@ -28,6 +28,7 @@ import app.revanced.integrations.shared.settings.Setting;
 import app.revanced.integrations.shared.settings.StringSetting;
 import app.revanced.integrations.shared.settings.preference.SharedPrefCategory;
 import app.revanced.integrations.youtube.patches.alternativethumbnails.AlternativeThumbnailsPatch.DeArrowAvailability;
+import app.revanced.integrations.youtube.patches.alternativethumbnails.AlternativeThumbnailsPatch.DeArrowAlternativeDomainAvailability;
 import app.revanced.integrations.youtube.patches.alternativethumbnails.AlternativeThumbnailsPatch.StillImagesAvailability;
 import app.revanced.integrations.youtube.patches.alternativethumbnails.AlternativeThumbnailsPatch.ThumbnailOption;
 import app.revanced.integrations.youtube.patches.alternativethumbnails.AlternativeThumbnailsPatch.ThumbnailStillTime;
@@ -58,7 +59,8 @@ public class Settings extends BaseSettings {
     public static final BooleanSetting ALT_THUMBNAIL_DEARROW_CONNECTION_TOAST = new BooleanSetting("revanced_alt_thumbnail_dearrow_connection_toast", FALSE, new DeArrowAvailability());
     public static final EnumSetting<ThumbnailStillTime> ALT_THUMBNAIL_STILLS_TIME = new EnumSetting<>("revanced_alt_thumbnail_stills_time", ThumbnailStillTime.MIDDLE, new StillImagesAvailability());
     public static final BooleanSetting ALT_THUMBNAIL_STILLS_FAST = new BooleanSetting("revanced_alt_thumbnail_stills_fast", FALSE, new StillImagesAvailability());
-    public static final BooleanSetting ALT_THUMBNAIL_ALTERNATIVE_DOMAIN = new BooleanSetting("revanced_alt_thumbnail_alternative_domain", FALSE);
+    public static final StringSetting ALT_THUMBNAIL_ALTERNATIVE_DOMAIN_NAME = new StringSetting("revanced_alt_thumbnail_alternative_domain_name", "yt4.ggpht.com", new DeArrowAlternativeDomainAvailability());
+    public static final BooleanSetting ALT_THUMBNAIL_ALTERNATIVE_DOMAIN_ENABLE = new BooleanSetting("revanced_alt_thumbnail_alternative_domain_enable", FALSE);
 
 
     // PreferenceScreen: Feed


### PR DESCRIPTION
Added option to change original youtube images domain for users from countries, where it blocked

anddea/revanced-patches#672

